### PR TITLE
Add ability to persist snippets under home directory

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,36 @@
 ## Snippet manager for Zazu
 
+## Configuration (default)
+
+By default the plugin will store your snippets in your home directory under `.zazu-snippets`.
+
+## Configuration (specific folder name)
+
+Changing the folder name from `.zazu-snippets` to `snippets` in your home directory.
+
+~~~ javascript
+{
+  "name": "afaur/zazu-snippets",
+  "variables": {
+    "folder": "snippets"
+  }
+}
+~~~
+
+## Configuration (specific containing directory)
+
+Changing the folder name from `.zazu-snippets` to `snippets` and storing it in a specific directory.
+
+~~~ javascript
+{
+  "name": "afaur/zazu-snippets",
+  "variables": {
+    "directory": "/Users/username/Documents",
+    "folder": "snippets"
+  }
+}
+~~~
+
 ## Usage
 
 Finding a snippet:

--- a/src/delete.js
+++ b/src/delete.js
@@ -1,20 +1,13 @@
 module.exports = (pluginContext) => {
-  const { cwd, console } = pluginContext
-  const snippets = require('./lib/snippets')(cwd, console)
-
   return (key, env = {}) => {
+    const { console } = pluginContext
+    const snippets = require('./lib/snippets')(console, env)
     return new Promise((resolve, reject) => {
       const value = snippets.search(key)
-      if (!value) {
-        return Promise.resolve()
-      } else {
-        resolve([{
-          id: key,
-          title: `Delete snippet called "${key}"`,
-          value: key,
-        }])
-      }
+      const deleteConfirm = [{
+        id: key, title: `Delete snippet called "${key}"`, value: key,
+      }]
+      resolve(value ? deleteConfirm : [])
     })
   }
 }
-

--- a/src/deleteSnippet.js
+++ b/src/deleteSnippet.js
@@ -1,8 +1,7 @@
 module.exports = (pluginContext) => {
-  const { cwd, console } = pluginContext
-  const snippets = require('./lib/snippets')(cwd, console)
-
   return (name, env = {}) => {
+    const { console } = pluginContext
+    const snippets = require('./lib/snippets')(console, env)
     snippets.delete(name)
     return Promise.resolve()
   }

--- a/src/lib/snippets.js
+++ b/src/lib/snippets.js
@@ -1,14 +1,19 @@
 const fs = require('fs')
+const os = require('os')
 const path = require('path')
 const fuzzy = require('fuzzyfind')
 const { htmlEncode } = require('js-htmlencode')
 
 class Snippets {
-  constructor (dir, console) {
-    this.dir = dir
+  constructor (console, env={}) {
+    // If user defined a folder name use it otherwise use zazu-snippets
+    const folder = (env.hasOwnProperty('folder')) ? env.folder : 'zazu-snippets'
+    // Default is os specific `[home_directory]/zazu-snippets`
+    this.snippetDir = path.join(os.homedir(), folder)
+    // Make directory if it does not already exist
+    if (!fs.existsSync(this.snippetDir)) { fs.mkdirSync(this.snippetDir) }
     this.index = {}
     this.console = console
-    this.snippetDir = path.join(this.dir, 'snippets')
     this.indexSnippets()
   }
 
@@ -67,6 +72,6 @@ class Snippets {
 }
 
 var singleton = null
-module.exports = (dir, console) => {
-  return singleton || (singleton = new Snippets(dir, console))
+module.exports = (console, env={}) => {
+  return singleton || (singleton = new Snippets(console, env))
 }

--- a/src/lib/snippets.js
+++ b/src/lib/snippets.js
@@ -6,15 +6,27 @@ const { htmlEncode } = require('js-htmlencode')
 
 class Snippets {
   constructor (console, env={}) {
-    // If user defined a folder name use it otherwise use zazu-snippets
-    const folder = (env.hasOwnProperty('folder')) ? env.folder : 'zazu-snippets'
-    // Default is os specific `[home_directory]/zazu-snippets`
-    this.snippetDir = path.join(os.homedir(), folder)
+    this.console = console
+    this.env = env
+    // Default or configured path to snippet directory
+    this.snippetDir = path.join(this.getDirectory(), this.getFolder())
     // Make directory if it does not already exist
     if (!fs.existsSync(this.snippetDir)) { fs.mkdirSync(this.snippetDir) }
     this.index = {}
-    this.console = console
     this.indexSnippets()
+  }
+
+  // Determines if a variable was set
+  envHas(variable) { return this.env.hasOwnProperty(variable) }
+
+  // If user defined a directory use it otherwise use home directory
+  getDirectory() {
+    return (this.envHas('directory') ? path.normalize(this.env.directory) : os.homedir())
+  }
+
+  // If user defined a folder name use it otherwise use .zazu-snippets
+  getFolder() {
+    return (this.envHas('folder') ? this.env.folder : '.zazu-snippets')
   }
 
   indexSnippets () {

--- a/src/read.js
+++ b/src/read.js
@@ -1,14 +1,10 @@
 module.exports = (pluginContext) => {
   return (query, env = {}) => {
     const { cwd, console } = pluginContext
+    const snippets = require('./lib/snippets')(console, env)
     return new Promise((resolve, reject) => {
-      const snippets = require('./lib/snippets')(cwd, console)
       const results = snippets.search(query)
-      if (!results) {
-        resolve([])
-      } else {
-        resolve(results)
-      }
+      resolve(results ? results : [])
     })
   }
 }

--- a/src/writeSnippet.js
+++ b/src/writeSnippet.js
@@ -1,8 +1,7 @@
 module.exports = (pluginContext) => {
-  const { cwd, console } = pluginContext
-  const snippets = require('./lib/snippets')(cwd, console)
-
   return (name, env = {}) => {
+    const { console } = pluginContext
+    const snippets = require('./lib/snippets')(console, env)
     const content = pluginContext.clipboard.readText()
     snippets.create(name, content)
     return Promise.resolve()


### PR DESCRIPTION
This removes the snippets folder from inside the plugin and instead will by default place a folder inside of your home directory to store snippets.

- Configurable snippet folder name
  - Info on setting variables...
    - Info (http://zazuapp.org/documentation/configuration/#plugins)
    - Example of..
      - Setting `folder` to 'snippets' instead of default '.zazu-snippets'
      - Setting `directory` to `/Users/username/Documents` instead of the os specific home dir
      ```json
      {
        "name": "afaur/zazu-snippets",
        "variables": {
          "directory": "/Users/username/Documents",
          "folder": "snippets"
        }
      },
      ```
  - Use variable `folder` to change folder name or it will default to '.zazu-snippets'
  - Use variable `directory` to change directory location or it will default to an os specific home dir
- Make snippet folder default to user home directory
  - Snippets by default will be inside...
    - Mac OSX `/Users/<username>/.zazu-snippets`
    - Windows 10 `<root>\Users\<username>\.zazu-snippets`